### PR TITLE
Added input morph parameters to the output

### DIFF
--- a/diffpy/pdfmorph/pdfmorphapp.py
+++ b/diffpy/pdfmorph/pdfmorphapp.py
@@ -199,6 +199,9 @@ def main():
     xref, yref = getPDFFromFile(pargs[1])
 
     # Get configuration values
+    scale_in = 'None'
+    stretch_in = 'None'
+    smear_in = 'None'
     config = {}
     config["rmin"] = opts.rmin
     config["rmax"] = opts.rmax
@@ -215,16 +218,19 @@ def main():
 
     ## Scale
     if opts.scale is not None:
+        scale_in = opts.scale
         chain.append(morphs.MorphScale())
         config["scale"] = opts.scale
         refpars.append("scale")
     ## Stretch
     if opts.stretch is not None:
+        stretch_in = opts.stretch
         chain.append(morphs.MorphStretch())
         config["stretch"] = opts.stretch
         refpars.append("stretch")
     ## Smear
     if opts.smear is not None:
+        smear_in = opts.smear
         chain.append(morphs.MorphXtalPDFtoRDF())
         chain.append(morphs.MorphSmear())
         chain.append(morphs.MorphXtalRDFtoPDF())
@@ -305,9 +311,16 @@ def main():
     chain[0] = morphs.Morph()
     chain(xobj, yobj, xref, yref)
 
+    morphs_in = "\nInput morphing parameters:"
+    morphs_in += f"\n scale = {scale_in}"
+    morphs_in += f"\n stretch = {stretch_in}"
+    morphs_in += f"\n smear = {smear_in}"
+    print(morphs_in)
+
     items = list(config.items())
     items.sort()
-    output = "\n".join("# %s = %f" % i for i in items)
+    output = "\n Optimized morphing parameters:"
+    output += "\n".join("# %s = %f" % i for i in items)
     output += "\n# Rw = %f" % rw
     output += "\n# Pearson = %f" % pcc
     print(output)
@@ -315,6 +328,7 @@ def main():
         header = "# PDF created by pdfmorph\n"
         header += "# from %s\n" % os.path.abspath(pargs[0])
 
+        header += morphs_in
         header += output
         if opts.savefile == "-":
             outfile = sys.stdout

--- a/diffpy/pdfmorph/pdfmorphapp.py
+++ b/diffpy/pdfmorph/pdfmorphapp.py
@@ -311,15 +311,15 @@ def main():
     chain[0] = morphs.Morph()
     chain(xobj, yobj, xref, yref)
 
-    morphs_in = "\nInput morphing parameters:"
-    morphs_in += f"\n scale = {scale_in}"
-    morphs_in += f"\n stretch = {stretch_in}"
-    morphs_in += f"\n smear = {smear_in}"
+    morphs_in = "\n# Input morphing parameters:"
+    morphs_in += f"\n# scale = {scale_in}"
+    morphs_in += f"\n# stretch = {stretch_in}"
+    morphs_in += f"\n# smear = {smear_in}"
     print(morphs_in)
 
     items = list(config.items())
     items.sort()
-    output = "\nOptimized morphing parameters:\n"
+    output = "\n# Optimized morphing parameters:\n"
     output += "\n".join("# %s = %f" % i for i in items)
     output += "\n# Rw = %f" % rw
     output += "\n# Pearson = %f" % pcc

--- a/diffpy/pdfmorph/pdfmorphapp.py
+++ b/diffpy/pdfmorph/pdfmorphapp.py
@@ -319,7 +319,7 @@ def main():
 
     items = list(config.items())
     items.sort()
-    output = "\n Optimized morphing parameters:"
+    output = "\nOptimized morphing parameters:\n"
     output += "\n".join("# %s = %f" % i for i in items)
     output += "\n# Rw = %f" % rw
     output += "\n# Pearson = %f" % pcc


### PR DESCRIPTION
closes #44 

Here's before
<img width="574" alt="Screen Shot 2023-03-13 at 4 50 54 AM" src="https://user-images.githubusercontent.com/68021211/224652023-dcecad13-2ed6-47ab-9a90-a483ca223d5b.png">

and after
<img width="388" alt="Screen Shot 2023-03-13 at 4 50 29 AM" src="https://user-images.githubusercontent.com/68021211/224652040-8fe498b5-0244-4711-a509-73951efa556e.png">

and here is the new save file that it creates for the morphed PDF in case we should avoid altering the file format I can revert the additional parameters in the save file.
<img width="515" alt="Screen Shot 2023-03-13 at 4 53 56 AM" src="https://user-images.githubusercontent.com/68021211/224652643-f82142a7-d09a-4595-8cf2-a4a4dde4d215.png">
