### PR TITLE
Update terminology

### DIFF
--- a/diffpy/pdfmorph/morph_helpers/__init__.py
+++ b/diffpy/pdfmorph/morph_helpers/__init__.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+##############################################################################
+#
+# diffpy.pdfmorph   by DANSE Diffraction group
+#                   Simon J. L. Billinge
+#                   (c) 2010 Trustees of the Columbia University
+#                   in the City of New York.  All rights reserved.
+#
+# See AUTHORS.txt for a list of people who contributed.
+# See LICENSE.txt for license information.
+#
+##############################################################################
+
+"""List of helpers for certain morphing operations (currently only used for smear)."""
+
+from diffpy.pdfmorph.morph_helpers.transformpdftordf import TransformXtalPDFtoRDF
+from diffpy.pdfmorph.morph_helpers.transformrdftopdf import TransformXtalRDFtoPDF
+
+# List of helpers
+morph_helpers = [
+    TransformXtalPDFtoRDF,
+    TransformXtalRDFtoPDF,
+]
+
+

--- a/diffpy/pdfmorph/morph_helpers/transformpdftordf.py
+++ b/diffpy/pdfmorph/morph_helpers/transformpdftordf.py
@@ -14,17 +14,17 @@
 ##############################################################################
 
 
-"""class MorphXtalRDFtoPDF -- Morph crystal RDFs to PDFs.
+"""class TransformXtalPDFtoRDF -- Transform crystal PDFs to RDFs.
 """
 
 
 from diffpy.pdfmorph.morphs.morph import *
 
 
-class MorphXtalRDFtoPDF(Morph):
-    '''Morph crystal RDFs to PDFs.
+class TransformXtalPDFtoRDF(Morph):
+    '''Transform crystal PDFs to RDFs.
 
-    This morphs both the morph data and the target data.
+    Converts both morph data and target data PDFs to RDFs.
 
     Configuration variables:
 
@@ -33,30 +33,26 @@ class MorphXtalRDFtoPDF(Morph):
                         is the density of the crystalline sample.
 
     With s = baselineslope,
-    G(r) = R(r) / r + r * s
+    R(r) = r * (G(r) - r * s)
 
     '''
 
     # Define input output types
     summary = 'Turn the PDF into the RDF for both the morph and target'
     xinlabel = LABEL_RA
-    yinlabel = LABEL_RR
+    yinlabel = LABEL_GR
     xoutlabel = LABEL_RA
-    youtlabel = LABEL_GR
+    youtlabel = LABEL_RR
     parnames = ["baselineslope"]
 
     def morph(self, x_morph, y_morph, x_target, y_target):
-        """Morph to the PDF."""
+        """Return corresponding RDF given PDF."""
         Morph.morph(self, x_morph, y_morph, x_target, y_target)
         morph_baseline = self.baselineslope * self.x_morph_in
+        self.y_morph_out = self.x_morph_in * (self.y_morph_in - morph_baseline)
         target_baseline = self.baselineslope * self.x_target_in
-        self.y_target_out = self.y_target_in / self.x_target_in + target_baseline
-        if self.x_target_in[0] == 0:
-            self.y_target_out[0] = 0
-        self.y_morph_out = self.y_morph_in / self.x_morph_in + morph_baseline
-        if self.x_morph_in[0] == 0:
-            self.y_morph_out[0] = 0
+        self.y_target_out = self.x_target_in * (self.y_target_in - target_baseline)
         return self.xyallout
 
 
-# End of class MorphScale
+# End of class TransformXtalPDFtoRDF

--- a/diffpy/pdfmorph/morph_helpers/transformrdftopdf.py
+++ b/diffpy/pdfmorph/morph_helpers/transformrdftopdf.py
@@ -14,17 +14,17 @@
 ##############################################################################
 
 
-"""class MorphXtalPDFtoRDF -- Morph crystal PDFs to RDFs.
+"""class TransformXtalRDFtoPDF -- Transform crystal RDFs to PDFs.
 """
 
 
 from diffpy.pdfmorph.morphs.morph import *
 
 
-class MorphXtalPDFtoRDF(Morph):
-    '''Morph crystal PDFs to RDFs.
+class TransformXtalRDFtoPDF(Morph):
+    '''Transform crystal RDFs to PDFs.
 
-    This morphs both the morph data and the target data.
+    Converts both morph data and target data RDFs to PDFs.
 
     Configuration variables:
 
@@ -33,26 +33,30 @@ class MorphXtalPDFtoRDF(Morph):
                         is the density of the crystalline sample.
 
     With s = baselineslope,
-    R(r) = r * (G(r) - r * s)
+    G(r) = R(r) / r + r * s
 
     '''
 
     # Define input output types
     summary = 'Turn the PDF into the RDF for both the morph and target'
     xinlabel = LABEL_RA
-    yinlabel = LABEL_GR
+    yinlabel = LABEL_RR
     xoutlabel = LABEL_RA
-    youtlabel = LABEL_RR
+    youtlabel = LABEL_GR
     parnames = ["baselineslope"]
 
     def morph(self, x_morph, y_morph, x_target, y_target):
-        """Morph to the RDF."""
+        """Return corresponding PDF given RDF."""
         Morph.morph(self, x_morph, y_morph, x_target, y_target)
         morph_baseline = self.baselineslope * self.x_morph_in
-        self.y_morph_out = self.x_morph_in * (self.y_morph_in - morph_baseline)
         target_baseline = self.baselineslope * self.x_target_in
-        self.y_target_out = self.x_target_in * (self.y_target_in - target_baseline)
+        self.y_target_out = self.y_target_in / self.x_target_in + target_baseline
+        if self.x_target_in[0] == 0:
+            self.y_target_out[0] = 0
+        self.y_morph_out = self.y_morph_in / self.x_morph_in + morph_baseline
+        if self.x_morph_in[0] == 0:
+            self.y_morph_out[0] = 0
         return self.xyallout
 
 
-# End of class MorphXtalPDFtoRDF
+# End of class MorphScale

--- a/diffpy/pdfmorph/morphs/__init__.py
+++ b/diffpy/pdfmorph/morphs/__init__.py
@@ -19,8 +19,6 @@
 
 from diffpy.pdfmorph.morphs.morph import Morph
 from diffpy.pdfmorph.morphs.morphchain import MorphChain
-from diffpy.pdfmorph.morphs.morphpdftordf import MorphXtalPDFtoRDF
-from diffpy.pdfmorph.morphs.morphrdftopdf import MorphXtalRDFtoPDF
 from diffpy.pdfmorph.morphs.morphresolution import MorphResolutionDamping
 from diffpy.pdfmorph.morphs.morphrgrid import MorphRGrid
 from diffpy.pdfmorph.morphs.morphscale import MorphScale
@@ -35,9 +33,7 @@ morphs = [
     MorphRGrid,
     MorphScale,
     MorphStretch,
-    MorphXtalPDFtoRDF,
     MorphSmear,
-    MorphXtalRDFtoPDF,
     MorphSphere,
     MorphSpheroid,
     MorphISphere,

--- a/diffpy/pdfmorph/morphs/morph.py
+++ b/diffpy/pdfmorph/morphs/morph.py
@@ -27,9 +27,7 @@ class Morph(object):
     '''Base class for implementing a morph given a target.
 
     Adapted from diffpy.pdfgetx to include two sets of arrays that get passed
-    through. In most cases, only the morph is modified, but it is
-    acceptable for morph the target as well, such as to change the range of
-    the array.
+    through.
 
     Note that attributes are taken from config when not found locally. The
     morph may modify the config dictionary. This is the means by which to

--- a/diffpy/pdfmorph/morphs/morphishape.py
+++ b/diffpy/pdfmorph/morphs/morphishape.py
@@ -74,8 +74,8 @@ class MorphISpheroid(Morph):
         """Apply a scale factor."""
         Morph.morph(self, x_morph, y_morph, x_target, y_target)
         f = _spheroidalCF(x_morph, self.iradius, self.ipradius)
-        self.y_morph_out[f != 0] /= f  # Divide non-zero entries
-        self.y_morph_out[f == 0] = 0  # Set zero entries to zero
+        self.y_morph_out /= f
+        self.y_morph_out[f == 0] = 0
         return self.xyallout
 
 

--- a/diffpy/pdfmorph/morphs/morphshape.py
+++ b/diffpy/pdfmorph/morphs/morphshape.py
@@ -98,7 +98,7 @@ def _sphericalCF(r, psize):
     if psize > 0:
         x = r / psize
         g = 1.0 - 1.5 * x + 0.5 * x * x * x
-        g[x > 1] = 0
+        g[x > 1] = 0  # Assume zero atomic density outside particle
         f += g
     return f
 
@@ -144,11 +144,11 @@ def _spheroidalCF2(r, psize, axrat):
     d2 = d * d
     v2 = v * v
 
-    if v == 1:
+    if v == 1:  # Sphere
         return _sphericalCF(r, psize)
 
     rx = r
-    if v < 1:
+    if v < 1:  # Prolate spheroid
         r = rx[rx <= v * psize]
         r2 = r * r
         f1 = (
@@ -179,7 +179,7 @@ def _spheroidalCF2(r, psize, axrat):
 
         f = numpy.concatenate((f1, f2, f3))
 
-    elif v > 1:
+    elif v > 1:  # Oblate spheroid
         r = rx[rx <= psize]
         r2 = r * r
         f1 = (

--- a/diffpy/pdfmorph/pdfmorph_api.py
+++ b/diffpy/pdfmorph/pdfmorph_api.py
@@ -21,7 +21,7 @@ if sys.version_info.major < 3:
     from collections import Iterable
 else:
     from collections.abc import Iterable
-from diffpy.pdfmorph import morphs
+from diffpy.pdfmorph import morphs, morph_helpers
 from diffpy.pdfmorph import refine as ref
 from diffpy.pdfmorph import tools
 import matplotlib.pyplot as plt
@@ -32,7 +32,7 @@ import matplotlib.pyplot as plt
 _morph_step_dict = dict(
     scale=morphs.MorphScale,
     stretch=morphs.MorphStretch,
-    smear=[morphs.MorphXtalPDFtoRDF, morphs.MorphSmear, morphs.MorphXtalRDFtoPDF],
+    smear=[morph_helpers.TransformXtalPDFtoRDF, morphs.MorphSmear, morph_helpers.TransformXtalRDFtoPDF],
     qdamp=morphs.MorphResolutionDamping,
 )
 _default_config = dict(

--- a/diffpy/pdfmorph/pdfmorphapp.py
+++ b/diffpy/pdfmorph/pdfmorphapp.py
@@ -25,6 +25,7 @@ from diffpy.pdfmorph import __version__
 import diffpy.pdfmorph.tools as tools
 import diffpy.pdfmorph.pdfplot as pdfplot
 import diffpy.pdfmorph.morphs as morphs
+import diffpy.pdfmorph.morph_helpers as helpers
 import diffpy.pdfmorph.refine as refine
 
 
@@ -267,9 +268,9 @@ def main():
     ## Smear
     if opts.smear is not None:
         smear_in = opts.smear
-        chain.append(morphs.MorphXtalPDFtoRDF())
+        chain.append(helpers.TransformXtalPDFtoRDF())
         chain.append(morphs.MorphSmear())
-        chain.append(morphs.MorphXtalRDFtoPDF())
+        chain.append(helpers.TransformXtalRDFtoPDF())
         refpars.append("smear")
         config["smear"] = opts.smear
         config["baselineslope"] = opts.baselineslope

--- a/diffpy/pdfmorph/tests/test_morphpdftordf.py
+++ b/diffpy/pdfmorph/tests/test_morphpdftordf.py
@@ -11,10 +11,10 @@ thisfile = locals().get('__file__', 'file.py')
 tests_dir = os.path.dirname(os.path.abspath(thisfile))
 # testdata_dir = os.path.join(tests_dir, 'testdata')
 
-from diffpy.pdfmorph.morphs.morphpdftordf import MorphXtalPDFtoRDF
+from diffpy.pdfmorph.morph_helpers.transformpdftordf import TransformXtalPDFtoRDF
 
 
-class TestMorphXtalPDFtoRDF(unittest.TestCase):
+class TestTransformXtalPDFtoRDF(unittest.TestCase):
     def setUp(self):
         self.x_morph = numpy.arange(0.01, 5, 0.01)
         self.y_morph = numpy.exp(-0.5 * (self.x_morph - 1.0) ** 2) / self.x_morph - self.x_morph
@@ -22,12 +22,12 @@ class TestMorphXtalPDFtoRDF(unittest.TestCase):
         self.y_target = numpy.exp(-0.5 * (self.x_morph - 2.0) ** 2) / self.x_morph - self.x_morph
         return
 
-    def test_morph(self):
-        """check MorphXtalPDFtoRDF.morph()"""
+    def test_transform(self):
+        """check TransformXtalPDFtoRDF.morph()"""
         config = {"baselineslope": -1.0}
-        morph = MorphXtalPDFtoRDF(config)
+        transform = TransformXtalPDFtoRDF(config)
 
-        x_morph, y_morph, x_target, y_target = morph(self.x_morph, self.y_morph, self.x_target, self.y_target)
+        x_morph, y_morph, x_target, y_target = transform(self.x_morph, self.y_morph, self.x_target, self.y_target)
 
         rdf1 = numpy.exp(-0.5 * (x_morph - 1.0) ** 2)
         rdf2 = numpy.exp(-0.5 * (x_target - 2.0) ** 2)
@@ -36,7 +36,7 @@ class TestMorphXtalPDFtoRDF(unittest.TestCase):
         return
 
 
-# End of class TestMorphXtalPDFtoRDF
+# End of class TestTransformXtalPDFtoRDF
 
 if __name__ == '__main__':
     unittest.main()

--- a/diffpy/pdfmorph/tests/test_morphrdftopdf.py
+++ b/diffpy/pdfmorph/tests/test_morphrdftopdf.py
@@ -11,10 +11,10 @@ thisfile = locals().get('__file__', 'file.py')
 tests_dir = os.path.dirname(os.path.abspath(thisfile))
 # testdata_dir = os.path.join(tests_dir, 'testdata')
 
-from diffpy.pdfmorph.morphs.morphrdftopdf import MorphXtalRDFtoPDF
+from diffpy.pdfmorph.morph_helpers.transformrdftopdf import TransformXtalRDFtoPDF
 
 
-class TestMorphXtalRDFtoPDF(unittest.TestCase):
+class TestTransformXtalRDFtoPDF(unittest.TestCase):
     def setUp(self):
         self.x_morph = numpy.arange(0.01, 5, 0.01)
         self.y_morph = numpy.exp(-0.5 * (self.x_morph - 1.0) ** 2)
@@ -22,12 +22,12 @@ class TestMorphXtalRDFtoPDF(unittest.TestCase):
         self.y_target = numpy.exp(-0.5 * (self.x_morph - 2.0) ** 2)
         return
 
-    def test_morph(self):
-        """check MorphXtalRDFtoPDF.morph()"""
+    def test_transform(self):
+        """check TransformXtalRDFtoPDF.morph()"""
         config = {"baselineslope": -1.0}
-        morph = MorphXtalRDFtoPDF(config)
+        transform = TransformXtalRDFtoPDF(config)
 
-        x_morph, y_morph, x_target, y_target = morph(self.x_morph, self.y_morph, self.x_target, self.y_target)
+        x_morph, y_morph, x_target, y_target = transform(self.x_morph, self.y_morph, self.x_target, self.y_target)
 
         rdf1 = numpy.exp(-0.5 * (x_morph - 1.0) ** 2) / x_morph - x_morph
         rdf2 = numpy.exp(-0.5 * (x_target - 2.0) ** 2) / x_target - x_target
@@ -36,7 +36,7 @@ class TestMorphXtalRDFtoPDF(unittest.TestCase):
         return
 
 
-# End of class TestMorphXtalRDFtoPDF
+# End of class TestTransformXtalRDFtoPDF
 
 if __name__ == '__main__':
     unittest.main()

--- a/diffpy/pdfmorph/tests/test_morphshape.py
+++ b/diffpy/pdfmorph/tests/test_morphshape.py
@@ -47,10 +47,18 @@ class TestMorphSpheroid(unittest.TestCase):
 
     def test_morph(self):
         """check MorphSphere.morph()"""
-        config = {
+        config_oblate = {
             "radius": 17.5,
             "pradius": 5.0,
         }
+        # FIXME: add test data for prolate spheroids and spheres
+        configs = [config_oblate]
+
+        for config in configs:
+            self.shape_test_helper(config)
+        return
+
+    def shape_test_helper(self, config):
         morph = MorphSpheroid(config)
 
         x_morph, y_morph, x_target, y_target = morph(self.x_morph, self.y_morph, self.x_target, self.y_target)

--- a/diffpy/pdfmorph/tests/test_refine.py
+++ b/diffpy/pdfmorph/tests/test_refine.py
@@ -15,8 +15,8 @@ from diffpy.pdfmorph.morphs.morphchain import MorphChain
 from diffpy.pdfmorph.morphs.morphscale import MorphScale
 from diffpy.pdfmorph.morphs.morphstretch import MorphStretch
 from diffpy.pdfmorph.morphs.morphsmear import MorphSmear
-from diffpy.pdfmorph.morphs.morphpdftordf import MorphXtalPDFtoRDF
-from diffpy.pdfmorph.morphs.morphrdftopdf import MorphXtalRDFtoPDF
+from diffpy.pdfmorph.morph_helpers.transformpdftordf import TransformXtalPDFtoRDF
+from diffpy.pdfmorph.morph_helpers.transformrdftopdf import TransformXtalRDFtoPDF
 from diffpy.pdfmorph.refine import Refiner
 
 
@@ -99,9 +99,9 @@ class TestRefineUC(unittest.TestCase):
         chain = MorphChain(config)
         chain.append(MorphScale())
         chain.append(MorphStretch())
-        chain.append(MorphXtalPDFtoRDF())
+        chain.append(TransformXtalPDFtoRDF())
         chain.append(MorphSmear())
-        chain.append(MorphXtalRDFtoPDF())
+        chain.append(TransformXtalRDFtoPDF())
 
         refiner = Refiner(chain, self.x_morph, self.y_morph, self.x_target, self.y_target)
 

--- a/doc/source/morph_helpers.rst
+++ b/doc/source/morph_helpers.rst
@@ -1,0 +1,18 @@
+PDFmorph.morph_helpers Package
+#######################
+
+diffpy.pdfmorph.morph_helpers.transformpdftordf module
+===========================================
+
+.. automodule:: diffpy.pdfmorph.morph_helpers.transformpdftordf
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+diffpy.pdfmorph.morph_helpers.transformrdftopdf module
+===========================================
+
+.. automodule:: diffpy.pdfmorph.morph_helpers.transformrdftopdf
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/morphs.rst
+++ b/doc/source/morphs.rst
@@ -28,23 +28,6 @@ diffpy.pdfmorph.morphs.morphishape module
     :undoc-members:
     :show-inheritance:
 
-
-diffpy.pdfmorph.morphs.morphpdftordf module
-===========================================
-
-.. automodule:: diffpy.pdfmorph.morphs.morphpdftordf
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-diffpy.pdfmorph.morphs.morphrdftopdf module
-===========================================
-
-.. automodule:: diffpy.pdfmorph.morphs.morphrdftopdf
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 diffpy.pdfmorph.morphs.morphresolution module
 =============================================
 

--- a/doc/source/package.rst
+++ b/doc/source/package.rst
@@ -10,6 +10,7 @@ Submodules
     :titlesonly:
 
     morphs
+    morph_helpers
     mod_pdfplot
     mod_refine
     mod_tools


### PR DESCRIPTION
Addresses #76. However, TransformPDFtoRDF and TransformRDFtoPDF still have 'morph' functions. Changing the names of these may be a bit difficult as we would have to change the terminology used by the MorphChain class.

We could change MorphChain -> ProcessChain and rename the function to 'process' rather than 'morph'. However, I prefer 'morph' since most classes (other than these two transforms) with the function are morphs.