### PR TITLE
Bump flake8 version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort


### PR DESCRIPTION
The PyCharm default character limit per line is 120, and I think the longer lines (~115) makes the code less cluttered.

When using `Black`, it is [recommended](https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#labels-why-pycodestyle-warnings) to ignore `E203`, `E701`, `E704`, `W503`. By default, `W503` should be disabled by `flake8`, but removing that warning from `ignore` gives a bunch of those errors.