### PR TITLE
Fix typo in CI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@
 .. |Black| image:: https://img.shields.io/badge/code_style-black-black
         :target: https://github.com/psf/black
 
-.. |CI| image:: https://github.com/diffpy/diffpy.pdfmoprh/actions/workflows/matrix-and-codecov-on-merge-to-main.yml/badge.svg
-        :target: https://github.com/diffpy/diffpy.pdfmoprh/actions/workflows/matrix-and-codecov-on-merge-to-main.yml
+.. |CI| image:: https://github.com/diffpy/diffpy.pdfmorph/actions/workflows/matrix-and-codecov-on-merge-to-main.yml/badge.svg
+        :target: https://github.com/diffpy/diffpy.pdfmorph/actions/workflows/matrix-and-codecov-on-merge-to-main.yml
 
 .. |Codecov| image:: https://codecov.io/gh/diffpy/diffpy.pdfmorph/branch/main/graph/badge.svg
         :target: https://codecov.io/gh/diffpy/diffpy.pdfmorph


### PR DESCRIPTION
<img width="89" alt="Screenshot 2024-10-05 at 1 27 36 PM" src="https://github.com/user-attachments/assets/07389e50-75f0-4a40-83aa-bb5835a97d42">

https://github.com/diffpy/diffpy.pdfmorph/actions/workflows/matrix-and-codecov-on-merge-to-main.yml/badge.svg

Works now..