### PR TITLE
Allow `None` as parameter value in morphpy

### DIFF
--- a/news/allow_none.rst
+++ b/news/allow_none.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* In morphpy, when a parameter is set to None, it will not be used as an option.
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/morph/morphpy.py
+++ b/src/diffpy/morph/morphpy.py
@@ -27,14 +27,6 @@ def get_args(parser, params, kwargs):
 
 
 def __get_morph_opts__(parser, scale, stretch, smear, plot, **kwargs):
-    # Check for Python-specific options
-    python_morphs = ["funcy", "funcx", "funcxy"]
-    pymorphs = {}
-    for pmorph in python_morphs:
-        if pmorph in kwargs:
-            pmorph_value = kwargs.pop(pmorph)
-            pymorphs.update({pmorph: pmorph_value})
-
     # Special handling of parameters with dashes
     kwargs_copy = kwargs.copy()
     kwargs = {}
@@ -43,6 +35,15 @@ def __get_morph_opts__(parser, scale, stretch, smear, plot, **kwargs):
         if "_" in key:
             new_key = key.replace("_", "-")
         kwargs.update({new_key: kwargs_copy[key]})
+
+    # Check for Python-specific options
+    python_morphs = ["funcy", "funcx", "funcxy"]
+    pymorphs = {}
+    for pmorph in python_morphs:
+        if pmorph in kwargs:
+            pmorph_value = kwargs.pop(pmorph)
+            if pmorph_value is not None:
+                pymorphs.update({pmorph: pmorph_value})
 
     # Special handling of store_true and store_false parameters
     opts_storing_values = [

--- a/src/diffpy/morph/morphpy.py
+++ b/src/diffpy/morph/morphpy.py
@@ -12,14 +12,16 @@ def get_args(parser, params, kwargs):
             inputs.append(f"--{key}")
             inputs.append(f"{value}")
     for key, value in kwargs.items():
-        key = key.replace("_", "-")
-        if key == "exclude":
-            for param in value:
+        if value is not None:
+            key = key.replace("_", "-")
+            if key == "exclude":
+                for param in value:
+                    if param:
+                        inputs.append(f"--{key}")
+                        inputs.append(f"{param}")
+            else:
                 inputs.append(f"--{key}")
-                inputs.append(f"{param}")
-        else:
-            inputs.append(f"--{key}")
-            inputs.append(f"{value}")
+                inputs.append(f"{value}")
     (opts, pargs) = parser.parse_args(inputs)
     return opts, pargs
 

--- a/tests/test_morphpy.py
+++ b/tests/test_morphpy.py
@@ -116,6 +116,38 @@ class TestMorphpy:
             else:
                 assert getattr(opts, opt)
 
+        # Check that morphs can be set as None
+        kwargs = {
+            "hshift": None,
+            "vshift": None,
+            "squeeze": None,
+            "funcx": None,
+            "funcy": None,
+            "funcxy": None,
+            "verbose": None,
+            "addpearson": None,
+            "apply": None,
+            "exclude": None,
+            "reverse": None,
+            "get_diff": None,
+            "multiple_morphs": None,
+            "multiple_targets": None,
+        }
+        kwargs_copy = kwargs.copy()
+        opts, pymorphs = __get_morph_opts__(
+            self.parser,
+            scale=1,
+            stretch=0,
+            smear=0,
+            plot=False,
+            **kwargs_copy,
+        )
+        for opt in kwargs:
+            try:
+                assert not getattr(opts, opt)
+            except AttributeError:
+                pass
+
     def test_morph(self, setup_morph):
         morph_results = {}
         morph_file = self.testfiles[0]


### PR DESCRIPTION
When `None` is set for `stretch`,`scale`,`smear`, it will ignore these parameters. However, setting `None` for any other parameter would give an error. We now handle letting any parameter being `None` and ignore it properly in `morphpy`.