### PR TITLE
Support 3.14. Switch from loadData->load_data.

### DIFF
--- a/docs/source/funcxy.rst
+++ b/docs/source/funcxy.rst
@@ -40,7 +40,7 @@ kapton background ``background.chi``.
 
      from diffpy.pdfgetx.pdfgetter import PDFGetter
      from diffpy.morph.morphpy import morph_arrays
-     from diffpy.utils.parsers.loaddata import loadData
+     from diffpy.utils.parsers import load_data
 
      pg = PDFGetter()
 
@@ -60,8 +60,8 @@ kapton background ``background.chi``.
          return (r, gr)
 
 
-     sample_iq = loadData("sample.chi")
-     target_gr = loadData("target.cgr")
+     sample_iq = load_data("sample.chi")
+     target_gr = load_data("target.cgr")
      params_to_morph = {
          "bgscale": 1.0,
          "qmin": 0.0, "qmax": 25.0,
@@ -124,7 +124,7 @@ our wavelength was ``1.11`` angstroms.
      import pyFAI.integrator.azimuthal as pyfai
      import pyFAI.detectors as pfd
      from diffpy.morph.morphpy import morph_arrays
-     from diffpy.utils.parsers.loaddata import loadData
+     from diffpy.utils.parsers.load_data import load_data
 
      pattern_2d = np.load("diffraction_image.npy")
      wavelength = 0.1110e-9  # in m
@@ -163,8 +163,8 @@ our wavelength was ``1.11`` angstroms.
          "cent_offset_y": 0  # in number of pixels
      }
 
-     sample_chi = loadData("sample.chi")
-     target_chi = loadData("target.chi")
+     sample_chi = load_data("sample.chi")
+     target_chi = load_data("target.chi")
 
      morph_info, morphed_chi = morph_arrays(
                                      sample_chi, target_chi,

--- a/news/3.14.rst
+++ b/news/3.14.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Updated support from 3.11-3.13 to 3.12-3.14.
+* Requires diffpy.utils>=3.7.1.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 description = "Python package for manipulating and comparing 1D signals."
 keywords = ['diffpy', 'pdf', 'data interpretation']
 readme = "README.rst"
-requires-python = ">=3.11, <3.14"
+requires-python = ">=3.12, <3.15"
 classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
@@ -25,9 +25,9 @@ classifiers = [
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Operating System :: Unix',
-        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Scientific/Engineering :: Physics',
         'Topic :: Scientific/Engineering :: Chemistry',
 ]

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -1,5 +1,5 @@
 numpy
 scipy
-diffpy.utils>=3.6.1
+diffpy.utils>=3.7.1
 matplotlib-base
 bg-mpl-stylesheets

--- a/src/diffpy/morph/morph_api.py
+++ b/src/diffpy/morph/morph_api.py
@@ -245,7 +245,7 @@ def morph(
         chain(x_morph, y_morph, x_target, y_target)
 
     # summary
-    rw = tools.getRw(chain)
+    rw = tools.get_rw(chain)
     pcc = tools.get_pearson(chain)
     # restore rgrid
     chain[0] = morphs.Morph()

--- a/src/diffpy/morph/morphapp.py
+++ b/src/diffpy/morph/morphapp.py
@@ -527,8 +527,8 @@ def single_morph(
         x_target = pargs[4]
         y_target = pargs[5]
     else:
-        x_morph, y_morph = getPDFFromFile(pargs[0])
-        x_target, y_target = getPDFFromFile(pargs[1])
+        x_morph, y_morph = get_two_column_from_file(pargs[0])
+        x_target, y_target = get_two_column_from_file(pargs[1])
 
     if y_morph is None:
         parser.morph_error(f"No data table found in: {pargs[0]}.", ValueError)
@@ -754,7 +754,7 @@ def single_morph(
     io.handle_extrapolation_warnings(stretch_morph)
 
     # Get Rw for the morph range
-    rw = tools.getRw(chain)
+    rw = tools.get_rw(chain)
     pcc = tools.get_pearson(chain)
     # Replace the MorphRGrid with Morph identity
     # This removes the r-range morph as mentioned above
@@ -1261,11 +1261,12 @@ def multiple_morphs(parser, opts, pargs, stdout_flag=True, python_wrap=False):
     return morph_results
 
 
-def getPDFFromFile(fn):
-    from diffpy.morph.tools import readPDF
+def get_two_column_from_file(fn):
+    """Open a two column data file and extract the data."""
+    from diffpy.morph.tools import read_two_column
 
     try:
-        r, gr = readPDF(fn)
+        x, fx = read_two_column(fn)
     except IOError as errmsg:
         print("%s: %s" % (fn, errmsg), file=sys.stderr)
         sys.exit(1)
@@ -1273,7 +1274,7 @@ def getPDFFromFile(fn):
         print("Cannot read %s" % fn, file=sys.stderr)
         sys.exit(1)
 
-    return r, gr
+    return x, fx
 
 
 def main():

--- a/src/diffpy/morph/tools.py
+++ b/src/diffpy/morph/tools.py
@@ -17,18 +17,18 @@
 
 import numpy
 
-from diffpy.utils.parsers.loaddata import loadData
+from diffpy.utils.parsers import load_data
 from diffpy.utils.parsers.serialization import deserialize_data
 
 
-def estimateScale(y_morph_in, y_target_in):
+def estimate_scale(y_morph_in, y_target_in):
     """Set the scale that best matches the morph to the target."""
     dot = numpy.dot
     scale = dot(y_morph_in, y_target_in) / dot(y_morph_in, y_morph_in)
     return scale
 
 
-def estimateBaselineSlope(r, gr, rmin=None, rmax=None):
+def estimate_baseline_slope(r, gr, rmin=None, rmax=None):
     """Estimate the slope of the linear baseline of a PDF.
 
     This fits a slope into the equation slope*r through the bottom of the PDF.
@@ -85,7 +85,7 @@ def estimateBaselineSlope(r, gr, rmin=None, rmax=None):
     return slope
 
 
-def getRw(chain):
+def get_rw(chain):
     """Get Rw from the outputs of a morph or chain."""
     # Make sure we put these on the proper grid
     x_morph, y_morph, x_target, y_target = chain.xyallout
@@ -104,8 +104,8 @@ def get_pearson(chain):
     return pcc
 
 
-def readPDF(fname):
-    """Reads an .gr file, loads r and G(r) vectors.
+def read_two_column(fname):
+    """Reads a two-column data file, loads x and f(x) vectors.
 
     Parameters
     ----------
@@ -114,11 +114,11 @@ def readPDF(fname):
 
     Returns
     -------
-    r,gr
+    x,fx
         Arrays read from data.
     """
 
-    rv = loadData(fname, unpack=True)
+    rv = load_data(fname, unpack=True)
     if len(rv) >= 2:
         return rv[:2]
     return (None, None)
@@ -207,7 +207,7 @@ def field_sort(
     files_field_values = []
     if serfile is None:
         for path in filepaths:
-            fhd = loadData(path, headers=True)
+            fhd = load_data(path, headers=True)
             files_field_values.append(
                 [path, case_insensitive_dictionary_search(field, fhd)]
             )

--- a/src/diffpy/morph/tools.py
+++ b/src/diffpy/morph/tools.py
@@ -116,7 +116,6 @@ def read_two_column(fname):
     x,fx
         Arrays read from data.
     """
-
     rv = load_data(fname, unpack=True)
     if len(rv) >= 2:
         return rv[:2]

--- a/tests/test_morphio.py
+++ b/tests/test_morphio.py
@@ -11,7 +11,7 @@ from diffpy.morph.morphapp import (
     single_morph,
 )
 from diffpy.morph.morphpy import morph_arrays
-from diffpy.utils.parsers.loaddata import loadData
+from diffpy.utils.parsers import load_data
 
 # Support Python 2
 try:
@@ -68,9 +68,9 @@ def are_files_same(file1, file2):
 def are_diffs_right(file1, file2, diff_file):
     """Assert that diff_file ordinate data is approximately file1
     ordinate data minus file2 ordinate data."""
-    f1_data = loadData(file1)
-    f2_data = loadData(file2)
-    diff_data = loadData(diff_file)
+    f1_data = load_data(file1)
+    f2_data = load_data(file2)
+    diff_data = load_data(diff_file)
 
     xmin = max(min(f1_data[:, 0]), min(f1_data[:, 1]))
     xmax = min(max(f2_data[:, 0]), max(f2_data[:, 1]))

--- a/tests/test_morphpy.py
+++ b/tests/test_morphpy.py
@@ -7,7 +7,7 @@ import pytest
 
 from diffpy.morph.morphapp import create_option_parser, single_morph
 from diffpy.morph.morphpy import __get_morph_opts__, morph, morph_arrays
-from diffpy.morph.tools import getRw
+from diffpy.morph.tools import get_rw
 
 thisfile = locals().get("__file__", "file.py")
 tests_dir = Path(thisfile).parent.resolve()
@@ -166,7 +166,7 @@ class TestMorphpy:
                 xyallout = grm[:, 0], grm[:, 1], grt[:, 0], grt[:, 1]
 
             chain = Chain()
-            rw = getRw(chain)
+            rw = get_rw(chain)
             del chain
             assert np.allclose(
                 [rw], [self.morphapp_results[target_file.name]["Rw"]]
@@ -237,7 +237,7 @@ class TestMorphpy:
                 xyallout = grm[:, 0], grm[:, 1], grt[:, 0], grt[:, 1]
 
             chain = Chain()
-            rw = getRw(chain)
+            rw = get_rw(chain)
             del chain
             assert np.allclose(
                 [rw], [self.morphapp_results[target_file.name]["Rw"]]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -27,9 +27,9 @@ class TestTools:
         self.rho0 = 0.0917132
         return
 
-    def test_estimateBaselineSlope(self, setup):
+    def test_estimate_baseline_slope(self, setup):
         """Check estimateBaselineSlope() using calculated data."""
-        slope = tools.estimateBaselineSlope(self.x_morph, self.y_morph)
+        slope = tools.estimate_baseline_slope(self.x_morph, self.y_morph)
         slopecalc = -4 * numpy.pi * self.rho0
         assert numpy.allclose(slopecalc, slope, 1e-2)
         return
@@ -39,7 +39,7 @@ class TestTools:
         import random
 
         x = random.random()
-        scale = tools.estimateScale(self.y_morph, x * self.y_morph)
+        scale = tools.estimate_scale(self.y_morph, x * self.y_morph)
         assert x, scale
         return
 


### PR DESCRIPTION
Closes #293. Renamed all camel-case function names to Python-standard function names.

Update `pyproject.toml` to support Python `3.14`.